### PR TITLE
電話番号、郵便番号のバリデーションの変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+  include ActionController::Helpers
 
   skip_before_action :verify_authenticity_token
   helper_method :current_user, :user_signed_in?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,11 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  VALID_PHONENUMBER_REGEX = /\A\d{10}$|^\d{11}\z/
+
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :name, presence: true
-  validates :phone_number, presence: true
+  validates :phone_number, presence: true, format: { with: VALID_PHONENUMBER_REGEX }
   validates :post_code, presence: true
   validates :address, presence: true
   validates :building_name, presence: true

--- a/db/migrate/20211220110605_devise_token_auth_create_users.rb
+++ b/db/migrate/20211220110605_devise_token_auth_create_users.rb
@@ -32,8 +32,8 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
       
       t.string :email, null: false
       t.string :name, null: false
-      t.integer :phone_number, null: false
-      t.integer :post_code, null: false
+      t.string :phone_number, null: false
+      t.string :post_code, null: false
       t.string :address, null: false
       t.string :building_name, null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,8 +26,8 @@ ActiveRecord::Schema.define(version: 2021_12_20_110605) do
     t.string "unconfirmed_email"
     t.string "email", null: false
     t.string "name", null: false
-    t.integer "phone_number", null: false
-    t.integer "post_code", null: false
+    t.string "phone_number", null: false
+    t.string "post_code", null: false
     t.string "address", null: false
     t.string "building_name", null: false
     t.text "tokens"


### PR DESCRIPTION
## バリデーションの変更
データ型をintegerからstrinngに変更
```
VALID_PHONENUMBER_REGEX = /\A\d{10}$|^\d{11}\z/
```
```
validates :phone_number, presence: true, format: { with: VALID_PHONENUMBER_REGEX }
```
の追加でハイフンなし10桁or11桁の設定を追加しました。